### PR TITLE
Simplify unit test config

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,9 +17,9 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: runner
           POSTGRES_DB: passport-saml-cache-postgres-unittest
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -36,7 +36,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn test
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
       - run: yarn lint

--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -17,8 +17,6 @@ let remove: (key: string) => Promise<string | null>
 beforeAll(async () => {
   pool = new pg.Pool({
     database: 'passport-saml-cache-postgres-unittest',
-    user: process.env.POSTGRES_USER,
-    password: process.env.POSTGRES_PASSWORD,
   })
 
   const schema = await fs.readFile(path.join(__dirname, '../schema.sql'), 'utf-8')


### PR DESCRIPTION
The docker postres image supports a POSTGRES_HOST_AUTH_METHOD=trust
option for forgoing password authentication, so we can use it to remove
the authentication related bits.
